### PR TITLE
Fixed onError never being called when an error occurs

### DIFF
--- a/lib/src/async_button_builder.dart
+++ b/lib/src/async_button_builder.dart
@@ -415,7 +415,7 @@ class _AsyncButtonBuilderState extends State<AsyncButtonBuilder>
                             buttonState = const ButtonState.error();
                           });
 
-                          setTimer(widget.errorDuration, widget.onSuccess);
+                          setTimer(widget.errorDuration, widget.onError);
                         } else {
                           setState(() {
                             buttonState = const ButtonState.idle();


### PR DESCRIPTION
This fixes a typo, where the given `onError` callback is never actually called. I'm guessing a copy-paste error 🙂 